### PR TITLE
application: add "authorized_usernames" field

### DIFF
--- a/src/deployment.coffee
+++ b/src/deployment.coffee
@@ -4,6 +4,7 @@ Path      = require "path"
 Version   = require(Path.join(__dirname, "version")).Version
 Octonode  = require("octonode")
 ApiConfig = require(Path.join(__dirname, "api_config")).ApiConfig
+userIdToName = require(Path.join(__dirname, "user_id_map")).userIdToName
 ###########################################################################
 
 class Deployment
@@ -41,6 +42,10 @@ class Deployment
 
   isValidEnv: ->
     @env in @environments
+
+  isAuthorizedUser: (userid) ->
+    username = userIdToName(userid)
+    username in @application['authorized_usernames']
 
   isAllowedRoom: (room) ->
     !@allowedRooms? || room in @allowedRooms

--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -71,11 +71,15 @@ module.exports = (robot) ->
     hosts = (msg.match[6]||'')
 
     username = msg.envelope.user.githubLogin or msg.envelope.user.name
+    userid = msg.envelope.user.id
 
     deployment = new Deployment(name, ref, task, env, force, hosts)
 
     unless deployment.isValidApp()
       msg.reply "#{name}? Never heard of it."
+      return
+    unless deployment.isAuthorizedUser(userid)
+      msg.reply "you don't have permission to deploy it (user id: #{userid}) "
       return
     unless deployment.isValidEnv()
       msg.reply "#{name} doesn't seem to have an #{env} environment."
@@ -84,7 +88,7 @@ module.exports = (robot) ->
       msg.reply "#{name} is not allowed to be deployed from this room."
       return
 
-    user = robot.brain.userForId msg.envelope.user.id
+    user = robot.brain.userForId userid
     if user? and user.githubDeployToken?
       deployment.setUserToken(user.githubDeployToken)
 

--- a/src/user_id_map.coffee
+++ b/src/user_id_map.coffee
@@ -1,0 +1,7 @@
+Fs = require "fs"
+
+userIdMap = JSON.parse Fs.readFileSync('user-id-map.json').toString()
+
+userIdToName = (userId) -> userIdMap[userId]
+
+exports.userIdToName = userIdToName


### PR DESCRIPTION
resolves https://github.com/pagarme/SOX/issues/11

Agora o `apps.json` tem um novo parâmetro a mais em cada application, `authorized_usernames`, e para facilitar o seu uso, adicionei um novo arquivo de configuração, `user-id-map.json`.

O arquivo `user-id-map.json` serve para mapear o ID do Slack de um usuário em um nome mais fácil de se trabalhar. Por exemplo:

```
{
    "U9EBQK823": "bruno.macabeus",
    "UCSBS2VQF": "oki"
}
```

E então, podemos usar `bruno.macabeus` e `oki` no campo `authorized_usernames`. Por exemplo:

```json
{
    "service": {
        "provider": "deployer",
        "auto_merge": false,
        "repository": "pagarme/service",
        "environments": ["production"],
        "authorized_usernames": ["bruno.macabeus", "oki"]
    }
}
```