### PR TITLE
Create changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "hubot": ">=2.7.2 <=2.13.2",
     "timeago": "0.1.0",
     "sprintf": "0.1.3",
-    "octonode": "0.5.0",
+    "octonode": "0.9.5",
     "inflection": "1.3.6"
   },
   "devDependencies": {

--- a/src/changelog.coffee
+++ b/src/changelog.coffee
@@ -1,0 +1,63 @@
+Path = require "path"
+config = require(Path.join(__dirname, "config"))
+
+getCommitTitle = (commit) ->
+    commit.message.split('\n\n')[0]
+
+branchComparison = (api, repository, ref) ->
+  ghrepo = api.repo(repository)
+  new Promise (resolve, reject) ->
+    ghrepo.compare 'master', ref, (err, data) ->
+      if err
+        return reject err
+
+      resolve data.commits.map (commit) ->
+        url: commit.html_url
+        title: getCommitTitle(commit.commit)
+
+post = (api, ref, changes, userid) ->
+  ghrepo = api.repo(config.changelogRepository)
+  username = config.userIdToName(userid)
+  body = changes
+    .map (change) ->
+      "* [#{change.title}](#{change.url})"
+    .join '\n'
+
+  new Promise (resolve, reject) ->
+    ghrepo.createIssue({
+      title: 'Changelog',
+      body: """
+        ### Deploy infos
+
+        **Author:** #{username} (#{userid})
+        **From branch:** #{ref}
+        **Base branch:** master
+
+        ### Changelog
+
+        #{body}
+      """,
+    }, (err, data) ->
+      if err
+        return reject err
+
+      resolve(data.html_url)
+    )
+
+create = (api, repository, ref, userid) ->
+  branchComparison(
+    api,
+    repository,
+    ref,
+  )
+  .then (changes) ->
+    post(
+      api,
+      ref,
+      changes,
+      userid,
+    )
+
+module.exports = {
+    create,
+}

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -2,6 +2,10 @@ Fs = require "fs"
 
 config = JSON.parse Fs.readFileSync('hubot-deploy-config.json').toString()
 
+changelogRepository = config.changelogRepository
 userIdToName = (userId) -> config.userIdMap[userId]
 
-exports.userIdToName = userIdToName
+module.exports = {
+  changelogRepository,
+  userIdToName,
+}

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1,0 +1,7 @@
+Fs = require "fs"
+
+config = JSON.parse Fs.readFileSync('hubot-deploy-config.json').toString()
+
+userIdToName = (userId) -> config.userIdMap[userId]
+
+exports.userIdToName = userIdToName

--- a/src/deployment.coffee
+++ b/src/deployment.coffee
@@ -4,7 +4,7 @@ Path      = require "path"
 Version   = require(Path.join(__dirname, "version")).Version
 Octonode  = require("octonode")
 ApiConfig = require(Path.join(__dirname, "api_config")).ApiConfig
-userIdToName = require(Path.join(__dirname, "user_id_map")).userIdToName
+userIdToName = require(Path.join(__dirname, "config")).userIdToName
 ###########################################################################
 
 class Deployment

--- a/src/user_id_map.coffee
+++ b/src/user_id_map.coffee
@@ -1,7 +1,0 @@
-Fs = require "fs"
-
-userIdMap = JSON.parse Fs.readFileSync('user-id-map.json').toString()
-
-userIdToName = (userId) -> userIdMap[userId]
-
-exports.userIdToName = userIdToName


### PR DESCRIPTION
Adiciona a lógica de criar uma issue com o changelog do que está sendo deployado. O changelog deve conter cada novo commit e o link para ele, além do autor do deploy.
O changelog é obrigatório, e por isso o deploy deve ser abortado se houver algum erro ao tentar se gerar o changelog.

Para esse primeiro momento, só estamos comparando a branch que está deployando com a `master`, para assim obter os commits diferentes, a ser usado no changelog.

Como o repositório a se salvar as issues deve ser configurável, foi necessário fazer uma alteração no json de configuração. Ele foi renomeado de `user_id_map.json` para `hubot-deploy-config.json`, e sua estrutura foi modificada, para conseguir armazenar tanto o mapeado do `slack id` para o username do Slack, e também o repositório onde deve salvar as issues do changelog.
Agora o json é estruturado em algo como:

```json
{
    "changelogRepository": "pagarme/deploy-changelog",
    "userIdMap": {
        "U4MS6P52S": "marquinho.almeida",
        "U1NK5L1HB": "gustavolivrare",
        "U7ZA2RMGU": "vhaberkorn",
        "U06R1CD0W": "grvcoelho"
    }
}
```

Resolves https://github.com/pagarme/SOX/issues/11