### PR TITLE
Add/sharon show permissions

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1,11 +1,14 @@
 Fs = require "fs"
 
+applications = JSON.parse Fs.readFileSync("apps.json").toString()
+
 config = JSON.parse Fs.readFileSync('hubot-deploy-config.json').toString()
 
 changelogRepository = config.changelogRepository
 userIdToName = (userId) -> config.userIdMap[userId]
 
 module.exports = {
+  applications,
   changelogRepository,
   userIdToName,
 }

--- a/src/deployment.coffee
+++ b/src/deployment.coffee
@@ -4,12 +4,10 @@ Path      = require "path"
 Version   = require(Path.join(__dirname, "version")).Version
 Octonode  = require("octonode")
 ApiConfig = require(Path.join(__dirname, "api_config")).ApiConfig
-userIdToName = require(Path.join(__dirname, "config")).userIdToName
+{ applications, userIdToName } = require(Path.join(__dirname, "config"))
 ###########################################################################
 
 class Deployment
-  @APPS_FILE = process.env['HUBOT_DEPLOY_APPS_JSON'] or "apps.json"
-
   constructor: (@name, @ref, @task, @env, @force, @hosts) ->
     @room             = 'unknown'
     @user             = 'unknown'
@@ -20,11 +18,6 @@ class Deployment
     @environments     = [ "production" ]
     @requiredContexts = null
     @caFile           = Fs.readFileSync(process.env['HUBOT_CA_FILE']) if process.env['HUBOT_CA_FILE']
-
-    try
-      applications = JSON.parse(Fs.readFileSync(@constructor.APPS_FILE).toString())
-    catch
-      throw new Error("Unable to parse your apps.json file in hubot-deploy")
 
     @application = applications[@name]
 

--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -15,6 +15,7 @@ Patterns      = require(Path.join(__dirname, "..", "patterns"))
 Deployment    = require(Path.join(__dirname, "..", "deployment")).Deployment
 Formatters    = require(Path.join(__dirname, "..", "formatters"))
 changelog     = require(Path.join(__dirname, "..", "changelog"))
+applications  = require(Path.join(__dirname, "..", "config")).applications
 
 DeployPrefix   = Patterns.DeployPrefix
 DeployPattern  = Patterns.DeployPattern
@@ -22,6 +23,17 @@ DeploysPattern = Patterns.DeploysPattern
 
 ###########################################################################
 module.exports = (robot) ->
+  ###########################################################################
+  # show permissions
+  #
+  # Displays who can deploy for each project
+  robot.respond /show\s+permissions/i, (msg) ->
+    for key, value of applications
+      if value.authorized_usernames?.length > 0
+        msg.send "- *#{key}* can be deployed by: #{value.authorized_usernames}"
+      else
+        msg.send "- nobody has permissions to deploy *#{key}*"
+
   ###########################################################################
   # where can i deploy <app>
   #


### PR DESCRIPTION
Adiciona o comando `show permissions` para conseguirmos listar as aplicações que são deployáveis e  quem tem permissão para deployar cada uma dessas aplicações.

![image](https://user-images.githubusercontent.com/9501115/49542243-2bf7cb80-f8bc-11e8-8bed-208ac8dcd969.png)
