### PR TITLE
changelog: fix to use the default branch instead of always the master

### DIFF
--- a/src/scripts/deploy.coffee
+++ b/src/scripts/deploy.coffee
@@ -129,6 +129,7 @@ module.exports = (robot) ->
         msg.reply responseMessage if responseMessage?
     .catch (e) ->
       if (
+        e.body?.documentation_url == 'https://developer.github.com/v3/repos/#get' ||
         e.body?.documentation_url == 'https://developer.github.com/v3/repos/commits/#compare-two-commits' ||
         e.body?.documentation_url == 'https://developer.github.com/v3/issues/#create-an-issue'
       )


### PR DESCRIPTION
Até então, só usávamos como branch base para gerar os changelog a `master`, pois normalmente é a branch que usamos como referência para deploy.

Porém, em alguns projetos não usamos a `master`, mas sim outra branch default. Esse PR corrige isso, buscando do GitHub a branch default para se usar como base na geração do changelog.